### PR TITLE
[ISSUE-8] Upgrading cytoolz, preshed and thinc, elasticsearch and url…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,14 @@
 attrs==18.1.0
 click==6.7
 cymem==1.31.2
-cytoolz==0.8.2
+cytoolz==0.9.0.1
 dill==0.2.7.1
-elasticsearch==6.2.0
+elasticsearch==6.3.1
 elasticsearch-dsl==6.1.0
 Faker==0.8.15
 ipaddress==1.0.22
 more-itertools==4.1.0
+msgpack==0.6.1
 msgpack-numpy==0.4.1
 msgpack-python==0.5.6
 murmurhash==0.28.0
@@ -15,7 +16,7 @@ numpy==1.14.3
 pathlib==1.0.1
 plac==0.9.6
 pluggy==0.6.0
-preshed==1.0.0
+preshed==1.0.1
 py==1.5.3
 pytest==3.5.1
 python-dateutil==2.7.3
@@ -23,9 +24,9 @@ regex==2017.4.5
 six==1.11.0
 termcolor==1.1.0
 text-unidecode==1.2
-thinc==6.10.2
+thinc==6.10.3
 toolz==0.9.0
 tqdm==4.23.4
 ujson==1.35
-urllib3==1.22
+urllib3==1.24.1
 wrapt==1.10.11


### PR DESCRIPTION
I've upgraded dependencies to address the security vulnerability in `urllib3`. This also forced me to upgrade the `elasticsearch` client dependency.
In addition, this PR closes Issue https://github.com/elastic/anonymize-it/issues/8 - an upgrade to some NLP dependencies that were breaking compatibility with Python 3.7.

Regarding testing:
I tried running `pytest` from the root directory, but unfortunately I seem to be missing two dependencies 
`utils` and `google` for running the tests - I'll take a look and add some guidance into README on running the tests.

```
Traceback:
test_anonymize_it/test_readers.py:1: in <module>
    from anonymize_it import readers
anonymize_it/readers.py:5: in <module>
    import utils
E   ModuleNotFoundError: No module named 'utils'
```
```
Hint: make sure your test modules/packages have valid Python names.
Traceback:
test_anonymize_it/test_writers.py:1: in <module>
    from anonymize_it import writers
anonymize_it/writers.py:6: in <module>
    from google.oauth2 import service_account
E   ModuleNotFoundError: No module named 'google'
```