### PR TITLE
Bumping the version of urllib3 to 1.24.2 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,5 +44,5 @@ thinc==6.10.3
 toolz==0.9.0
 tqdm==4.23.4
 ujson==1.35
-urllib3==1.24.1
+urllib3==1.24.2
 wrapt==1.10.11


### PR DESCRIPTION
To patch a security vulnerability.
Tests passing (however it should be noted that none of the tests require a network connection, which means we're not really testing for the effects of introducing a new version of urllib3. However, I have enough trust that a minor version increment and a security patch won't break things).