### PR TITLE
Fixing the composite query for empty term in after parameter

### DIFF
--- a/anonymize_it/utils.py
+++ b/anonymize_it/utils.py
@@ -98,12 +98,13 @@ def composite_query(field, size, query=None, term=""):
                     "size": size,
                     "sources" : [
                         {field: {"terms": {"field": field}}}
-                    ],
-                    "after": {field: term}
+                    ]
                 }
             }
         }
     }
+    if term:
+        body["aggs"]["my_buckets"]["composite"]["after"] = {field: term}
     if query:
         body['query'] = query
     return json.dumps(body)


### PR DESCRIPTION
The composite query in utils.py errors for certain field types (Eg: IP addresses) when the parameter "term"  passed to it is empty.
This PR fixes that.